### PR TITLE
Fix crash when the device is closed with the subprocess running

### DIFF
--- a/device.h
+++ b/device.h
@@ -75,7 +75,7 @@ struct devbase {
 	struct List db_ReadOrphanList;
 	struct SignalSemaphore db_ReadOrphanListSem;
 	struct Process* db_Proc;
-	struct SignalSemaphore db_ProcExitSem;
+	struct SignalSemaphore db_ProcSem;
 };
 
 #ifndef DEVBASETYPE


### PR DESCRIPTION
As communicated earlier [on Mastodon](https://mastodon.social/@chainq/114834452717093054), during the rework from the ZZ9000 driver, the thread-safe close/expunge handling broke. In its current shape, `scsidayna.device` does not wait for its frame-handling subprocess to exit properly, and this means its code segment gets unloaded with the process still running, and this is usually lethal for the entire system. This is especially problematic for TCP/IP stacks like MiamiDx that handles its drivers in a very dynamic fashion.

This PR reinstates the right handling of the subtask's semaphore, therefore eliminating the crash. Tested on my Amiga 2000. I also added some explanation in comments, and renamed the semaphore, so hopefully its naming now is less ambiguous.