### PR TITLE
Tails or Heads

### DIFF
--- a/device.c
+++ b/device.c
@@ -397,7 +397,7 @@ __saveds VOID DevBeginIO( ASMR(a1) struct IOSana2Req *ioreq       ASMREG(a1),
     } else {
       ioreq->ios2_Req.io_Flags &= ~SANA2IOF_QUICK;
       ObtainSemaphore(&db->db_ReadListSem);
-      AddHead((struct List*)&db->db_ReadList, (struct Node*)ioreq);
+      AddTail((struct List*)&db->db_ReadList, (struct Node*)ioreq);
       ReleaseSemaphore(&db->db_ReadListSem);
       ioreq = NULL;
     }
@@ -428,7 +428,10 @@ __saveds VOID DevBeginIO( ASMR(a1) struct IOSana2Req *ioreq       ASMREG(a1),
       ioreq->ios2_Req.io_Flags &= ~SANA2IOF_QUICK;
       ioreq->ios2_Req.io_Error = 0;
       ObtainSemaphore(&db->db_WriteListSem);
-      AddHead((struct List*)&db->db_WriteList, (struct Node*)ioreq);
+      // The sending process reads from the head of the list,
+      // so add to the tail here, otherwise packets could go out
+      // in swapped order
+      AddTail((struct List*)&db->db_WriteList, (struct Node*)ioreq);
       ReleaseSemaphore(&db->db_WriteListSem);
       Signal((struct Task*)db->db_Proc, SIGBREAKF_CTRL_F);
       ioreq = NULL;

--- a/device.c
+++ b/device.c
@@ -917,11 +917,14 @@ __saveds void frame_proc() {
       if (recv & SIGBREAKF_CTRL_C) {
         D(("Terminate Requested"));
       } else {
-        if (morePackets)
-          time_req->tr_time.tv_micro = 1000L; // Still a yield, but less. If we take up too much SCSI time the file access slows down
-        else time_req->tr_time.tv_micro = 10000L;
-        SendIO((struct IORequest *)time_req);
-        recv = Wait(SIGBREAKF_CTRL_C | timerSignalMask | SIGBREAKF_CTRL_F);        
+        if (!morePackets) {
+          // we use unit VBLANK therefore the granularity of our wait will be 1/50th (1/60th)
+          // of a second. So essentially this will wait until the next vblank, unless
+          // signaled, which is good enough to yield.
+          time_req->tr_time.tv_micro = 1L;
+          SendIO((struct IORequest *)time_req);
+          recv = Wait(SIGBREAKF_CTRL_C | timerSignalMask | SIGBREAKF_CTRL_F);
+        }
       }
     } else {
         // Not enabled? Pause for a decent amount of time


### PR DESCRIPTION
This PR contains two small fixes or improvements:

* use `AddTail()` instead of `AddHead()` when queuing I/O requests. For writing, this is essential, because sending always reads the list from the head, so if the queue also inserts to the head, this means outgoing packets could be sent in reverse order. For reading this is less critical, except for example MiamiDx queues up multiple requests for faster I/O, and if both list processing starts from the head, the same I/O request gets reused most of the time, instead of all in the queue.

* changed yielding to take into account that UNIT_VBLANK has a granularity of 1/50th of a second (20000 microsecond). So essentially both the previous 1000 or 10000 microsecond values just waited until the next, or the next-next VBlank anyway - if no signal was received. Now yielding always just waits until the next VBlank or the next signal. Also, don't wait if there are more packets.

I only tested these changes on my fast Amiga 2000/060 with a very fast DMA SCSI controller. It's possible that they have ill-effects on slower systems, especially the yielding change, as now there's no wait if there are more packets.