### PR TITLE
fix reversed logic of CheckIO time_req safeguard

### DIFF
--- a/device.c
+++ b/device.c
@@ -1254,10 +1254,10 @@ __saveds void frame_proc() {
 	logMessage(db,"PacketServer: Shutting down [1]");
 	
 	// Make sure it's finished - this prevents an intermittent crash at shutdown!
-	if (CheckIO((struct IORequest *)time_req)) { // IO is pending
-        AbortIO((struct IORequest *)time_req);
-        WaitIO((struct IORequest *)time_req);  // wait until IO fully done
-    }
+	if (!CheckIO((struct IORequest *)time_req)) { // IO is pending
+		AbortIO((struct IORequest *)time_req);
+		WaitIO((struct IORequest *)time_req);  // wait until IO fully done
+	}
 	
 	D(("scsidayna_task: i/o shutdown\n"));
 	logMessage(db,"PacketServer: Shutting down [2]");


### PR DESCRIPTION
The `time_req` checking and aborting logic added in version 1.4 is reversed, and actually can cause crashes itself on some systems by calling `AbortIO()` on never added timer requests.

This is the case for example with MiamiDx, because MiamiDx opens and closes the device twice in rapid succession on an interface bring-up, and in the first case the above bug always triggers, causing writes to address `0x00000000` and `0x00000004` inside `AbortIO()`, as revealed by using Enforcer/MuForce. The test system was an Amiga 2000 with a 68060 accelerator, using Kickstart 3.1 (v40.63).

The logic was reversed, because when `CheckIO()` returned a non-`NULL` result, `AbortIO()` and `WaitIO` was called, however, according to the [AutoDocs](https://amigadev.elowar.com/read/ADCD_2.1/Includes_and_Autodocs_2._guide/node033E.html), `CheckIO` returns `NULL` when the `IORequest` was still pending, and returns a pointer to the passed `IORequest` otherwise. Therefore `AbortIO/WaitIO` must be called, when `CheckIO` returns `NULL`. The PR corrects this.